### PR TITLE
Fix error handling for puppeteer

### DIFF
--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -55,7 +55,7 @@ const Scraper = (url) =>
       .concat('httploader.p?file=sfgradebook001.w')
       .join('/')
 
-    const { promise, resolve } = iPromise()
+    const { promise, resolve, reject } = iPromise()
 
     const obj = {
 
@@ -86,9 +86,12 @@ const Scraper = (url) =>
         .then(() => page.type('#password', pass))
         .then(() => page.click('#bLogin'))
         .then(() => page.waitFor(250))
-        .then(() => page.waitForSelector('#dMessage', { hidden: true, timeout: 100 })
-          .catch(() => { throw new Error('Invalid login or password!') }))
+        .then(() => page.waitForSelector('#dMessage', { hidden: true, timeout: 100 }))
       )
+      .catch(e => {
+        browser.close()
+        reject("Puppeeter error when scraping Skyward!")
+      })
 
     return promise
 


### PR DESCRIPTION
I used this API for one of my projects and it was a great help, just wanted to fix something small:

Earlier the API would throw an error, ending the promise chain and not allowing it to be handled with a try/catch. I just made it reject the Promise and clean up the leftover Puppeteer instance.